### PR TITLE
fstat maps uid back to running user

### DIFF
--- a/fuse/fuse-nfs.c
+++ b/fuse/fuse-nfs.c
@@ -69,14 +69,14 @@ uid_t getuid(){
 
 static int map_uid(int possible_uid) {
     if (custom_uid != -1 && possible_uid == custom_uid){
-        return getuid();
+        return fuse_get_context()->uid;
     }
     return possible_uid;
 }
 
 static int map_gid(int possible_gid) {
     if (custom_gid != -1 && possible_gid == custom_gid){
-        return getgid();
+        return fuse_get_context()->gid;
     }
     return possible_gid;
 }


### PR DESCRIPTION
..not fuse mount owner for symmetry with the outbound uids we send in credentials.

As it stands today, if I log in as user A, and run the following command:
```
fuse-nfs -a -n "nfs://server/export?uid=1000&gid=1000" -m /my/mountpoint
```
and then subsequently log in as user B and `touch /my/mountpoint/some.file`, the operation will fail strangely, because it will map the current user to uid 1000 for outbound traffic to the nfs server, but it will map the same user back to **user A** on inbound traffic.  So we will be able to create the file, but fail setting properties on it because it doesn't appear to the client OS to be owned by the user who just created it.

This PR fixes the fstat operation so that the mapping is symmetrical; any user with access to the mountpoint will appear to the server to be uid 1000, and any file on the server owned by uid 1000 will appear to the running user to be owned by that user.

This change does seem to be a bit creepy, since it means that mounts using `-a` plus `uid` and `gid` will give access to any user who can get to the mountpoint, but on the other hand, we were already doing that for write operations, so arguably, this PR doesn't make anything less safe than it was before.

At some point we might want to consider replacing the whole mechanism with a safer two way mapping mechanism like the [docker user namespace mapping](https://docs.docker.com/engine/reference/commandline/dockerd/#detailed-information-on-subuidsubgid-ranges) but then again that would only be worthwhile if someone really needs it.
