### PR TITLE
Add dokanfuse2 to configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -47,7 +47,7 @@ if test x"$libiscsi_cv_HAVE_ST_ATIM" = x"yes"; then
     AC_DEFINE(HAVE_ST_ATIM,1,[Whether we have st_atim support])
 fi
 
-AC_SEARCH_LIBS([fuse_get_context], [fuse dokanfuse1.dll], [], [
+AC_SEARCH_LIBS([fuse_get_context], [fuse dokanfuse1.dll dokanfuse2.dll], [], [
   AC_MSG_ERROR([fuse library unavailable])
 ])
 


### PR DESCRIPTION
Dokany has now a beta release for dokany 2.0.0-BETA1, in which the library dokanfuse1.dll was renamed to dokanfuse2.dll. This pull request adds dokanfuse2.dll to the list of possible fuse libraries in configure.ac
