### PR TITLE
Fixed building instructions to work newest systems

### DIFF
--- a/README
+++ b/README
@@ -6,7 +6,7 @@ This is a fuse module that implements the NFS protocol.
 Building
 ========
 
-$ sudo apt-get install libfuse-dev libnfs1 libtool m4 automake libnfs-dev
+$ sudo apt-get install libfuse-dev libnfs13 libnfs-dev libtool m4 automake libnfs-dev xsltproc
 $ ./setup.sh
 $ ./configure
 $ make


### PR DESCRIPTION
libnfs1 is not available in Ubuntu 20.04
also "make install" will fail because /usr/bin/xsltproc is missing in default installation.
Except that, everything works fine, even inside LXC containers.