### PR TITLE
Initialise readlink output buffer

### DIFF
--- a/fuse/fuse-nfs.c
+++ b/fuse/fuse-nfs.c
@@ -329,6 +329,7 @@ fuse_nfs_readlink(const char *path, char *buf, size_t size)
 	LOG("fuse_nfs_readlink entered [%s]\n", path);
 
         memset(&cb_data, 0, sizeof(struct sync_cb_data));
+	*buf = 0;
 	cb_data.return_data = buf;
 	cb_data.max_size = size;
 


### PR DESCRIPTION
Otherwise the use of strncat in readlink_cb with generate incremental garbage if the caller of fuse_nfs_readlink does not clear the buffer beforehand, which seems to be the case in some situations.

Tested on CentOS 7.9, before the fix the output from something like "ls -la" on a directory full of symlinks was returning target names with all the previous other symlinks prefixing it.