### PR TITLE
Fix the errors in README and HELP about UMASK

### DIFF
--- a/README
+++ b/README
@@ -54,7 +54,7 @@ FUSE OPTIONS
 	[-g FUSE_GID|--gid=FUSE_GID]
 		Specifies the numeric gid of the mount owner.
 		Override the st_uid field set by the filesystem.
-	[-U UMASK|--umask=UMASK]
+	[-K UMASK|--umask=UMASK]
 		Override the permission bits in st_mode set by the filesystem. 
 		The resulting permission bits are the ones missing from the given umask value.  
 		The value is given in octal representation.

--- a/fuse/fuse-nfs.c
+++ b/fuse/fuse-nfs.c
@@ -866,7 +866,7 @@ void print_usage(char *name)
 			"\t [-r|--allow_root] \n"
 			"\t [-u FUSE_UID|--uid=FUSE_UID] \n"
 			"\t [-g FUSE_GID|--gid=FUSE_GID] \n"
-			"\t [-U UMASK|--umask=UMASK] \n"
+			"\t [-K UMASK|--umask=UMASK] \n"
 			"\t [-d|--direct_io] \n"
 			"\t [-k|--kernel_cache] \n"
 			"\t [-c|--auto_cache] \n"
@@ -934,7 +934,7 @@ int main(int argc, char *argv[])
 		{ "max_readahead", required_argument, 0, 'H' },
 		{ "async_read", no_argument, 0, 'A' },
 		{ "sync_read", no_argument, 0, 'S' },
-		{ "umask", required_argument, 0, 'U' },
+		{ "umask", required_argument, 0, 'K' },
 		{ "entry_timeout", required_argument, 0, 'E' },
 		{ "negative_timeout", required_argument, 0, 'N' },
 		{ "attr_timeout", required_argument, 0, 'T' },


### PR DESCRIPTION
This pull request fix the error of "umask" option help in readme file and source code.
In source code, using '-K' to parse "umask" option but when we print help, it tell us to use '-U' to claim it. 